### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server that provides access to LLMs using the LlamaIndexTS library.
 
+![I put some LLMs in your MCP for your LLMs](legit.png)
+
 <a href="https://glama.ai/mcp/servers/i1gantlfrs">
   <img width="380" height="200" src="https://glama.ai/mcp/servers/i1gantlfrs/badge" alt="mcp-llm MCP server" />
 </a>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An MCP server that provides access to LLMs using the LlamaIndexTS library.
 
-![I put some LLMs in your MCP for your LLMs](legit.png)
+<a href="https://glama.ai/mcp/servers/i1gantlfrs">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/i1gantlfrs/badge" alt="mcp-llm MCP server" />
+</a>
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [mcp-llm](https://glama.ai/mcp/servers/i1gantlfrs) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/i1gantlfrs">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/i1gantlfrs/badge" alt="mcp-llm MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.